### PR TITLE
`:` must be checked before `* ` (in `_prep_ffmpeg_log`)

### DIFF
--- a/mmfunctions
+++ b/mmfunctions
@@ -1162,8 +1162,8 @@ _prep_ffmpeg_log(){
     while getopts ":q" OPT ; do
         case "${OPT}" in
             q) NOLOG="Y";;
-            *) echo "bad option -${OPTARG}" ; _usage ;;
             :) echo "Option -${OPTARG} requires an argument" ; exit 1 ;;
+            *) echo "Bad option -${OPTARG}" ; _usage ;;
         esac
     done
     shift $(( ${OPTIND} - 1 ))


### PR DESCRIPTION
Question: The function `_usage` is called (I guess) two times in this package, but it is not defined here. Is it supposed to be defined in the instance which calls `mm`?