### PR TITLE
Modify loudness report

### DIFF
--- a/makebroadcast
+++ b/makebroadcast
@@ -379,6 +379,7 @@ MIDDLEOPTIONS+=(-map "[with_slate_video]" -map "[with_slate_stereo1]" -map "[wit
 
     _run_critical_event ffmpeg "${INPUTOPTIONS[@]}" "${FFMPEGINPUT[@]}" "${MIDDLEOPTIONS[@]}" "${OUTPUT}"
     echo
+    _lookup_final_loudness
     _summarize_make
     _deliver_output "${MAKEBROADCAST_DELIVERY_EMAIL_TO}"
     _log -e

--- a/mmfunctions
+++ b/mmfunctions
@@ -1424,11 +1424,11 @@ _prep_volume_adjustment(){
     unset VOLADJ
     if [[ "${VOLADJUST}" != "N" ]] ; then
         if [[ -f "${INGESTLOG}" ]] ; then
-            measured_I=$(_readingestlog "r128_integrated_loudness")
-            measured_LRA=$(_readingestlog "r128_loudness_range")
-            measured_TP=$(_readingestlog "measured_true_peak")
-            measured_thresh=$(_readingestlog "measured_threshold")
-            target_offset=$(_readingestlog "target_offset")
+            measured_I=$(_readingestlog "input_r128_integrated_loudness")
+            measured_LRA=$(_readingestlog "input_r128_loudness_range")
+            measured_TP=$(_readingestlog "input_measured_true_peak")
+            measured_thresh=$(_readingestlog "input_measured_threshold")
+            target_offset=$(_readingestlog "input_target_offset")
             LOUD_ADJ=$(_readingestlog "loudness_adjustment")
         fi
         if [ ! "${LOUD_ADJ}" ] ; then
@@ -1440,7 +1440,7 @@ _prep_volume_adjustment(){
 }
 
 _lookup_final_loudness(){
-    FFMPEGLOG=$(ls -t | head -n 1)
+    FFMPEGLOG=$(ls -t | grep "${0}" | head -n 1)
     PARSE_FOR_LOUNDESS=$(cat "${FFMPEGLOG}")
     output_i=$(echo "$LOUDNESS_DATA" | grep "output_i" | awk -F\" '{print $4}')
     output_lra=$(echo "$LOUDNESS_DATA" | grep "output_lra" | awk -F\" '{print $4}')

--- a/mmfunctions
+++ b/mmfunctions
@@ -1255,11 +1255,11 @@ _get_volume_adjustment(){
         target_offset=$(echo "$LOUDNESS_DATA" | grep "target_offset" | awk -F\" '{print $4}')
         LOUD_ADJ=$(echo "($measured_I - -24)*-1" | bc)
         if [[ -f "${INGESTLOG}" ]] ; then
-            _writeingestlog "measured_true_peak" "${measured_TP}"
-            _writeingestlog "r128_loudness_range" "${measured_LRA}"
-            _writeingestlog "r128_integrated_loudness" "${measured_I}"
-            _writeingestlog "measured_threshold" "${measured_thresh}"
-            _writeingestlog "target_offset" "${target_offset}"
+            _writeingestlog "input_measured_true_peak" "${measured_TP}"
+            _writeingestlog "input_r128_loudness_range" "${measured_LRA}"
+            _writeingestlog "input_r128_integrated_loudness" "${measured_I}"
+            _writeingestlog "input_measured_threshold" "${measured_thresh}"
+            _writeingestlog "input_target_offset" "${target_offset}"
             _writeingestlog "loudness_adjustment" "${LOUD_ADJ}"
         fi
     fi
@@ -1436,6 +1436,21 @@ _prep_volume_adjustment(){
         fi
         _report -dt "Integrated loudness for $(basename "${INPUT_MOVIE}") is ${measured_I} LUFS. Reference is -24 LUFS. Will adjust by ${LOUD_ADJ} LUFS"
         _add_audio_filter "loudnorm=measured_I=${measured_I}:measured_LRA=${measured_LRA}:measured_TP=${measured_TP}:measured_thresh=${measured_thresh}:offset=${target_offset}:linear=true:print_format=json"
+    fi
+}
+
+_lookup_final_loudness(){
+    FFMPEGLOG=$(ls -t | head -n 1)
+    PARSE_FOR_LOUNDESS=$(cat "${FFMPEGLOG}")
+    output_i=$(echo "$LOUDNESS_DATA" | grep "output_i" | awk -F\" '{print $4}')
+    output_lra=$(echo "$LOUDNESS_DATA" | grep "output_lra" | awk -F\" '{print $4}')
+    output_tp=$(echo "$LOUDNESS_DATA" | grep "output_tp" | awk -F\" '{print $4}')
+    output_thresh=$(echo "$LOUDNESS_DATA" | grep "output_thresh" | awk -F\" '{print $4}') 
+    if [[ -f "${INGESTLOG}" ]] ; then
+        _writeingestlog "r128_integrated_loudness" "${output_i}"
+        _writeingestlog "r128_loudness_range" "${output_lra}"
+        _writeingestlog "measured_true_peak" "${output_tp}"
+        _writeingestlog "measured_threshold" "${output_thresh}"
     fi
 }
 

--- a/mmfunctions
+++ b/mmfunctions
@@ -1435,7 +1435,7 @@ _prep_volume_adjustment(){
             _get_volume_adjustment "${SOURCEFILE}"
         fi
         _report -dt "Integrated loudness for $(basename "${INPUT_MOVIE}") is ${measured_I} LUFS. Reference is -24 LUFS. Will adjust by ${LOUD_ADJ} LUFS"
-        _add_audio_filter "loudnorm=measured_I=${measured_I}:measured_LRA=${measured_LRA}:measured_TP=${measured_TP}:measured_thresh=${measured_thresh}:offset=${target_offset}:linear=true:print_format=summary"
+        _add_audio_filter "loudnorm=measured_I=${measured_I}:measured_LRA=${measured_LRA}:measured_TP=${measured_TP}:measured_thresh=${measured_thresh}:offset=${target_offset}:linear=true:print_format=json"
     fi
 }
 


### PR DESCRIPTION
Makes email reports from ingestfile report post normalization loudness info.

I have been able to test this to the point of seeing that normalizaton is happening correctly and that the correct metadata is being stored in the capture log, however, there is something wrong with email reporting on my system. This could probably benefit from some testing on a CUNY setup, but I _think_ it works.