### PR TITLE
add encoding date

### DIFF
--- a/makederiv
+++ b/makederiv
@@ -534,6 +534,7 @@ while [[ "${@}" != "" ]] ; do
         OUTPUT_TMP="$OUTPUT"
         OUTPUT="${OUTPUT%.iso}.mpeg"
     fi
+    MIDDLEOPTIONS+=(-metadata creation_time=now)
 
     _filter_to_middle_option
     _run_critical_event ffmpeg "${INPUTOPTIONS[@]}" "${FFMPEGINPUT[@]}" "${MIDDLEOPTIONS[@]}" "${OUTPUT}"


### PR DESCRIPTION
will encode in mov, mp4 derivatives; at end because of conflicts with
broadcast slate middleoptions