### PR TITLE
Prevents warning when jpegs are in logs directory

### DIFF
--- a/verifytree
+++ b/verifytree
@@ -70,7 +70,7 @@ while [ "${*}" != "" ] ; do
         #begins search of metadata subdirectories, looks for directories that do not belong
         _runtest "There are directories in the metadata directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name!='depictions' and @name!='fileMeta' and @name!='frameMD5s' and @name!='logs' and @name!='fingerprints']/@name" -n "${TEMPTREE}"
         #looks in logs directory for any files that aren't .log or .txt
-        _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
+        _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
         #makes sure there is a capture.log in the log directory
         _runtest -i "This package needs a capture.log!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[@name='capture.log']/@name" -n "${TEMPTREE}"
         #makes sure there is a fileMeta directory


### PR DESCRIPTION
Stops warning about QC Tools output graphs in logs directory. 