### PR TITLE
verifytree, verfiypackage, and object_policies.xml updates

### DIFF
--- a/object_policies.xml
+++ b/object_policies.xml
@@ -3,6 +3,7 @@
   <policy type="and" name="Neither FFV1 nor Matroska and not Wave?">
     <rule name="Is it not Matroska?" value="Format" tracktype="General" occurrence="*" operator="!=">Matroska</rule>
     <rule name="Is it not FFV1?" value="Format" tracktype="Video" occurrence="*" operator="!=">FFV1</rule>
+    <rule name="Is it not Wave?" value="Format" tracktype="General" occurrence="*" operator="!=">Wave</rule>
   </policy>
   <policy type="and" name="Video Digitzation Test: Meets Matroska/FFV1 Recommandations?">
     <description>Example of a digitization specification of analog SD video to FFV1 and Matroska.</description>
@@ -64,5 +65,34 @@
       </policy>
       <rule name="Is Interlaced?" value="ScanType" tracktype="Video" occurrence="1" operator="=">Interlaced</rule>
     </policy>
+  </policy>
+  <policy type="and" name="Audio Digitization Test: Meets Wave/PCM Reccomendations?" license="CC-BY-4.0+">
+    <description>This is the common norm for WAVE audiofiles.&#xD;
+  Any WAVs not matching this policy should be inspected and possibly normalized to conform to this.</description>
+    <policy type="or" name="Signed Integer or Float?">
+      <rule name="Is signed Integer?" value="Format_Settings_Sign" tracktype="Audio" occurrence="*" operator="=">Signed</rule>
+      <rule name="Is floating point?" value="Format_Profile" tracktype="Audio" occurrence="*" operator="=">Float</rule>
+    </policy>
+    <policy type="and" name="Audio: Proper resolution?">
+      <description>This policy defines audio-resolution values that are proper for WAV.</description>
+      <policy type="or" name="Valid samplerate?">
+        <description>This was not implemented as rule in order to avoid irregular sampling rates.</description>
+        <rule name="Audio is 32 kHz?" value="SamplingRate" tracktype="Audio" occurrence="*" operator="=">32000</rule>
+        <rule name="Audio is 44.1 kHz?" value="SamplingRate" tracktype="Audio" occurrence="*" operator="=">44100</rule>
+        <rule name="Audio is 48 kHz?" value="SamplingRate" tracktype="Audio" occurrence="*" operator="=">48000</rule>
+        <rule name="Audio is 88.2 kHz?" value="SamplingRate" tracktype="Audio" occurrence="*" operator="=">88200</rule>
+        <rule name="Audio is 96 kHz?" value="SamplingRate" tracktype="Audio" occurrence="*" operator="=">96000</rule>
+        <rule name="Audio is 192 kHz?" value="SamplingRate" tracktype="Audio" occurrence="*" operator="=">192000</rule>
+      </policy>
+      <policy type="or" name="Valid bit depth?">
+        <rule name="Audio is 16 bit?" value="BitDepth" tracktype="Audio" occurrence="*" operator="=">16</rule>
+        <rule name="Audio is 24 bit?" value="BitDepth" tracktype="Audio" occurrence="*" operator="=">24</rule>
+        <rule name="Audio is 32 bit?" value="BitDepth" tracktype="Audio" occurrence="*" operator="=">32</rule>
+        <rule name="Audio is 8 bit?" value="BitDepth" tracktype="Audio" occurrence="*" operator="=">8</rule>
+      </policy>
+    </policy>
+    <rule name="Container is RIFF (WAV)?" value="Format" tracktype="General" occurrence="*" operator="=">Wave</rule>
+    <rule name="Encoding is linear PCM?" value="Format" tracktype="Audio" occurrence="*" operator="=">PCM</rule>
+    <rule name="Audio is 'Little Endian'?" value="Format_Settings_Endianness" tracktype="Audio" occurrence="*" operator="=">Little</rule>
   </policy>
 </policy>

--- a/object_policies.xml
+++ b/object_policies.xml
@@ -1,10 +1,10 @@
-<policy type="or" name="Apply policy if Matroska">
-  <description>Example of a digitization specification of analog SD video to FFV1 and Matroska. This policy contains a copy of another policy (Is this NTSC or PAL SD).</description>
-  <policy type="and" name="Not FFV1 and not Matroska?">
+<policy type="or" name="Apply policy if result of audio or video digitization">
+  <description>Example of a digitization specification of analog SD video to FFV1 and Matroska or audio to Wave. For video, this policy contains a copy of another policy (Is this NTSC or PAL SD).</description>
+  <policy type="and" name="Neither FFV1 nor Matroska and not Wave?">
     <rule name="Is it not Matroska?" value="Format" tracktype="General" occurrence="*" operator="!=">Matroska</rule>
     <rule name="Is it not FFV1?" value="Format" tracktype="Video" occurrence="*" operator="!=">FFV1</rule>
   </policy>
-  <policy type="and" name="Meets Matroska/FFV1 recommandations?">
+  <policy type="and" name="Video Digitzation Test: Meets Matroska/FFV1 Recommandations?">
     <description>Example of a digitization specification of analog SD video to FFV1 and Matroska.</description>
     <rule name="Is it Matroska?" value="Format" tracktype="General" occurrence="*" operator="=">Matroska</rule>
     <rule name="Matroska version 4 or greater?" value="Format_Version" tracktype="General" occurrence="*" operator="&gt;=">4</rule>

--- a/verifypackage
+++ b/verifypackage
@@ -77,7 +77,7 @@ while [ "${*}" != "" ] ; do
         else
             mediaconch --force -fs -p "${SCRIPTDIR}/object_policies.xml" "${OBJECT_FILE}"
         fi
-    done < <(find "${PACKAGE}/objects" -type f -size +0 "${OBJECTS_FIND_EXCLUSIONS[@]}")
+    done < <(find "${PACKAGE}/objects" -type f ! -name "*.tif" -size +0 "${OBJECTS_FIND_EXCLUSIONS[@]}")
     #verify the makebroadcast file
     if [ -f "${PACKAGE}/objects/service/${MEDIAID}.mov" ] ; then
         STATUS=$(mediaconch --force -fx -p "${SCRIPTDIR}/makebroadcast_policies.xml" "${PACKAGE}/objects/service/${MEDIAID}.mov" | xmlstarlet sel -N mc="https://mediaarea.net/mediaconch" -t -v mc:MediaConch/mc:media/mc:policy/@outcome -n)

--- a/verifypackage
+++ b/verifypackage
@@ -120,4 +120,10 @@ while [ "${*}" != "" ] ; do
             _assess_volume "${PACKAGE}/objects/access/podcast/${MEDIAID}.m4a"
         fi
     fi    
+    #verify the mp3 file
+    if [ -f "${PACKAGE}/objects/access/mp3/${MEDIAID}.mp3" ] ; then
+        if [[ "${ALL_TESTS}" == "Y"  ]] || [[ "${VOL_TEST}" == "Y"  ]] ; then
+                _assess_volume "${PACKAGE}/objects/access/mp3/${MEDIAID}.mp3"
+        fi        
+    fi        
 done

--- a/verifypackage
+++ b/verifypackage
@@ -114,4 +114,10 @@ while [ "${*}" != "" ] ; do
             mediaconch --force -fs -p "${SCRIPTDIR}/makedvd_policies.xml" "${PACKAGE}/objects/access/dvd/${MEDIAID}.iso"
         fi
     fi
+    #verify the podcast file
+    if [ -f "${PACKAGE}/objects/access/podcast/${MEDIAID}.m4a" ] ; then
+        if [[ "${ALL_TESTS}" == "Y"  ]] || [[ "${VOL_TEST}" == "Y"  ]] ; then
+            _assess_volume "${PACKAGE}/objects/access/podcast/${MEDIAID}.m4a"
+        fi
+    fi    
 done

--- a/verifypackage
+++ b/verifypackage
@@ -114,7 +114,7 @@ while [ "${*}" != "" ] ; do
             mediaconch --force -fs -p "${SCRIPTDIR}/makedvd_policies.xml" "${PACKAGE}/objects/access/dvd/${MEDIAID}.iso"
         fi
     fi
-    #verify the podcast file
+    #verify the audio podcast file
     if [ -f "${PACKAGE}/objects/access/podcast/${MEDIAID}.m4a" ] ; then
         if [[ "${ALL_TESTS}" == "Y"  ]] || [[ "${VOL_TEST}" == "Y"  ]] ; then
             _assess_volume "${PACKAGE}/objects/access/podcast/${MEDIAID}.m4a"

--- a/verifypackage
+++ b/verifypackage
@@ -123,7 +123,7 @@ while [ "${*}" != "" ] ; do
     #verify the mp3 file
     if [ -f "${PACKAGE}/objects/access/mp3/${MEDIAID}.mp3" ] ; then
         if [[ "${ALL_TESTS}" == "Y"  ]] || [[ "${VOL_TEST}" == "Y"  ]] ; then
-                _assess_volume "${PACKAGE}/objects/access/mp3/${MEDIAID}.mp3"
+            _assess_volume "${PACKAGE}/objects/access/mp3/${MEDIAID}.mp3"
         fi        
     fi        
 done

--- a/verifytree
+++ b/verifytree
@@ -54,6 +54,7 @@ while [ "${*}" != "" ] ; do
         FIRSTOBJECTEXTENSION="$(xmlstarlet sel -t -m "/tree/directory/directory[@name='objects']/file[1]" -v "substring-after(@name, '.')" -n  "${TEMPTREE}")"
         #if there is one object file and it uses a .wav extension, then run audio-specific tests 
         if [[ "${OBJECTCOUNT}" = 1 && "${FIRSTOBJECTEXTENSION}" = "wav" ]] ; then
+            _report -dt "running verifytree in audio mode on ${PACKAGE}" #the name of the package being verified
              # Here are tests for audio packages specifically
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-3)!='xlsx' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-2)!='log']/@name" -n "${TEMPTREE}"
@@ -63,7 +64,9 @@ while [ "${*}" != "" ] ; do
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.m4a']/@name" -n  "${TEMPTREE}"
             #looks for any directories within access directory that are not dvd, images, mp3, podcast, or youtube_up
             _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='mp3' and @name!='showwaves' and @name!='podcast']/@name" -n "${TEMPTREE}"
+             _report -dt "running verifytree in text mode on ${PACKAGE}" #the name of the package being verified
         else
+             _report -dt "running verifytree in video mode on ${PACKAGE}" #the name of the package being verified
             # Here are tests for non-audio packages (video and text-based) specifically
             #makes sure there is a service or pdf_1 directory
             _runtest -i "This package is missing the service or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='service']/@name" -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"

--- a/verifytree
+++ b/verifytree
@@ -43,10 +43,10 @@ while [ "${*}" != "" ] ; do
         MEDIAID=$(basename "${PACKAGE}")
         _report -dt "running verifytree on ${PACKAGE}" #the name of the package being verified
 
-            #make a new temp tree
-            TEMPTREE=$(_maketemp)
-            tree -DaNXs --du --timefmt "%Y-%m-%dT%H:%M:%SZ" -I "tree.xml|.DS_Store" "${PACKAGE}" > "${TEMPTREE}"
-            #if tree.xml exists, compare it to the specified xpath expressions of an AIP
+        #make a new temp tree
+        TEMPTREE=$(_maketemp)
+        tree -DaNXs --du --timefmt "%Y-%m-%dT%H:%M:%SZ" -I "tree.xml|.DS_Store" "${PACKAGE}" > "${TEMPTREE}"
+        #if tree.xml exists, compare it to the specified xpath expressions of an AIP
 
         #searching for upper-level directories
 

--- a/verifytree
+++ b/verifytree
@@ -66,6 +66,7 @@ while [ "${*}" != "" ] ; do
             _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='mp3' and @name!='showwaves' and @name!='podcast']/@name" -n "${TEMPTREE}"
         elif [[ "${FIRSTOBJECTEXTENSION}" = "tif" ]] ; then
              _report -dt "running verifytree in text mode on ${PACKAGE}" #the name of the package being verified
+              # Here are tests for text packages specifically
         else
              _report -dt "running verifytree in video mode on ${PACKAGE}" #the name of the package being verified
             # Here are tests for non-audio packages (video and text-based) specifically

--- a/verifytree
+++ b/verifytree
@@ -57,10 +57,14 @@ while [ "${*}" != "" ] ; do
              # Here are tests for audio packages specifically
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-3)!='xlsx' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-2)!='log']/@name" -n "${TEMPTREE}"
+            #looks for unexpected files in podcast directory
+            _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.m4a']/@name" -n  "${TEMPTREE}"
         else
             # Here are tests for video packages specifically
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
+            #looks for unexpected files in podcast directory
+            _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.mov']/@name" -n  "${TEMPTREE}"
         fi
         #searching for upper-level directories
 
@@ -132,8 +136,6 @@ while [ "${*}" != "" ] ; do
         _runtest "There are unexpected files in the mp3 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='mp3']/file[@name!='${MEDIAID}.mp3']/@name" -n  "${TEMPTREE}"
         #looks for unexpected directories in mp3 directory
         _runtest "There are unexpected directories in the mp3 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='mp3']/directory[count(@name)>0]/@name" -n "${TEMPTREE}"
-        #looks for unexpected files in podcast directory
-        _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.mov']/@name" -n  "${TEMPTREE}"
         #looks for unexpected directories in podcast directory
         _runtest "There are unexpected directories in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/directory[count(@name)>0]/@name" -n "${TEMPTREE}"
         #looks for unexpected files in service directory

--- a/verifytree
+++ b/verifytree
@@ -64,6 +64,7 @@ while [ "${*}" != "" ] ; do
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.m4a']/@name" -n  "${TEMPTREE}"
             #looks for any directories within access directory that are not dvd, images, mp3, podcast, or youtube_up
             _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='mp3' and @name!='showwaves' and @name!='podcast']/@name" -n "${TEMPTREE}"
+        elif [[ "${FIRSTOBJECTEXTENSION}" = "tif" ]] ; then
              _report -dt "running verifytree in text mode on ${PACKAGE}" #the name of the package being verified
         else
              _report -dt "running verifytree in video mode on ${PACKAGE}" #the name of the package being verified

--- a/verifytree
+++ b/verifytree
@@ -57,6 +57,8 @@ while [ "${*}" != "" ] ; do
              # Here are tests for audio packages specifically
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-3)!='xlsx' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-2)!='log']/@name" -n "${TEMPTREE}"
+            #looks in fileMeta access for unexpected directories that are not dvd, mp3, podcast, or youtube_up
+            _runtest "There are directories in the fileMeta access directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/directory[@name='access']/directory[@name!='mp3' and @name!='podcast' and @name!='showwaves']/@name" -n "${TEMPTREE}"
             #looks for unexpected files in podcast directory
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.m4a']/@name" -n  "${TEMPTREE}"
         else
@@ -67,6 +69,8 @@ while [ "${*}" != "" ] ; do
             _runtest -i "This package is missing the youtube or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='youtube_up' or @name='pdf_1']/@name" -n "${TEMPTREE}"
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
+            #looks in fileMeta access for unexpected directories that are not dvd, mp3, podcast, or youtube_up
+            _runtest "There are directories in the fileMeta access directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/directory[@name='access']/directory[@name!='dvd' and @name!='mp3' and @name!='podcast' and @name!='youtube_up' and @name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
             #looks for unexpected files in podcast directory
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.mov']/@name" -n  "${TEMPTREE}"
         fi
@@ -99,8 +103,6 @@ while [ "${*}" != "" ] ; do
         _runtest "There are files in the fileMeta objects directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/file[substring(@name,string-length(@name)-2)!='xml' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='json']/@name" -n "${TEMPTREE}"
         #looks in fileMeta service subdirectory for that aren't .txt, .xml, .json
         _runtest "There are files in the fileMeta service directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/directory[@name='service']/file[substring(@name,string-length(@name)-2)!='xml' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='json']/@name" -n "${TEMPTREE}"
-        #looks in fileMeta access for unexpected directories that are not dvd, mp3, podcast, youtube_up, pdf_1, or txt_1
-        _runtest "There are directories in the fileMeta access directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/directory[@name='access']/directory[@name!='dvd' and @name!='mp3' and @name!='podcast' and @name!='youtube_up' and @name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
         #looks in all directories under access for unexpected metadata files-- files that aren't .txt, .xml, .json
         _runtest "There are unexpected metadata files in fileMeta access subdirectories!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/directory[@name='access']/directory/file[substring(@name,string-length(@name)-2)!='xml' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='json']/@name" -n "${TEMPTREE}"
 

--- a/verifytree
+++ b/verifytree
@@ -70,6 +70,8 @@ while [ "${*}" != "" ] ; do
             _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='mp3' and @name!='showwaves' and @name!='podcast']/@name" -n "${TEMPTREE}"
             #looks for audiograph file in depictions directory
             _runtest -i "There is no audiograph file in the depictions directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='depictions']/file[@name='${MEDIAID}_audiographs.png']/@name" -n  "${TEMPTREE}"
+            #looks for waveform file in depictions directory
+            _runtest -i "There is no waveform file in the depictions directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='depictions']/file[@name='${MEDIAID}_waveform.png']/@name" -n  "${TEMPTREE}"
         elif [[ "${FIRSTOBJECTEXTENSION}" = "tif" ]] ; then
              _report -dt "running verifytree in text mode on ${PACKAGE}" #the name of the package being verified
               # Here are tests for text packages specifically

--- a/verifytree
+++ b/verifytree
@@ -68,6 +68,8 @@ while [ "${*}" != "" ] ; do
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.m4a']/@name" -n  "${TEMPTREE}"
             #looks for any directories within access directory that are not dvd, images, mp3, podcast, or youtube_up
             _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='mp3' and @name!='showwaves' and @name!='podcast']/@name" -n "${TEMPTREE}"
+            #looks for audiograph file in depictions directory
+            _runtest -i "There is no audiograph file in the depictions directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='depictions']/file[@name='${MEDIAID}_audiographs.png']/@name" -n  "${TEMPTREE}"
         elif [[ "${FIRSTOBJECTEXTENSION}" = "tif" ]] ; then
              _report -dt "running verifytree in text mode on ${PACKAGE}" #the name of the package being verified
               # Here are tests for text packages specifically

--- a/verifytree
+++ b/verifytree
@@ -71,6 +71,8 @@ while [ "${*}" != "" ] ; do
             _runtest -i "This package is missing the pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
             #makes sure there is a pdf_1 directory
             _runtest -i "This package is missing the pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
+            #looks in logs directory for any files that aren't .log or .txt
+            _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
             #looks for any directories within access directory that are not pdf_1 or txt_1
             _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
         else

--- a/verifytree
+++ b/verifytree
@@ -48,6 +48,10 @@ while [ "${*}" != "" ] ; do
         tree -DaNXs --du --timefmt "%Y-%m-%dT%H:%M:%SZ" -I "tree.xml|.DS_Store" "${PACKAGE}" > "${TEMPTREE}"
         #if tree.xml exists, compare it to the specified xpath expressions of an AIP
 
+        #check number of object files
+        OBJECTCOUNT="$(xmlstarlet sel -t -m "/tree/directory/directory[@name='objects']" -v "count(file)" -n "${TEMPTREE}")"
+        #check extension of first object file
+        FIRSTOBJECTEXTENSION="$(xmlstarlet sel -t -m "/tree/directory/directory[@name='objects']/file[1]" -v "substring-after(@name, '.')" -n  "${TEMPTREE}")"
         #searching for upper-level directories
 
         #looks for any directories that are not objects or metadata or tmp (for digitized materials)

--- a/verifytree
+++ b/verifytree
@@ -71,6 +71,8 @@ while [ "${*}" != "" ] ; do
             _runtest -i "This package is missing the pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
             #makes sure there is a pdf_1 directory
             _runtest -i "This package is missing the pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
+            #looks for any directories within access directory that are not pdf_1 or txt_1
+            _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
         else
              _report -dt "running verifytree in video mode on ${PACKAGE}" #the name of the package being verified
             # Here are tests for non-audio packages (video and text-based) specifically
@@ -85,7 +87,7 @@ while [ "${*}" != "" ] ; do
             #looks for unexpected files in podcast directory
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.mov']/@name" -n  "${TEMPTREE}"
             #looks for any directories within access directory that are not dvd, images, mp3, podcast, or youtube_up
-            _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='dvd' and @name!='images' and @name!='mp3' and @name!='podcast' and @name!='youtube_up' and @name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
+            _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='dvd' and @name!='images' and @name!='mp3' and @name!='podcast' and @name!='youtube_up']/@name" -n "${TEMPTREE}"
         fi
         #searching for upper-level directories
 

--- a/verifytree
+++ b/verifytree
@@ -67,13 +67,15 @@ while [ "${*}" != "" ] ; do
         elif [[ "${FIRSTOBJECTEXTENSION}" = "tif" ]] ; then
              _report -dt "running verifytree in text mode on ${PACKAGE}" #the name of the package being verified
               # Here are tests for text packages specifically
+            #makes sure there is a pdf_1 directory
+            _runtest -i "This package is missing the pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
         else
              _report -dt "running verifytree in video mode on ${PACKAGE}" #the name of the package being verified
             # Here are tests for non-audio packages (video and text-based) specifically
-            #makes sure there is a service or pdf_1 directory
-            _runtest -i "This package is missing the service or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='service']/@name" -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
             #makes sure there is a youtube or pdf_1 directory
             _runtest -i "This package is missing the youtube or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='youtube_up' or @name='pdf_1']/@name" -n "${TEMPTREE}"
+            #makes sure there is a service directory
+            _runtest -i "This package is missing the service directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='service']/@name" -n "${TEMPTREE}"
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
             #looks in fileMeta access for unexpected directories that are not dvd, mp3, podcast, or youtube_up

--- a/verifytree
+++ b/verifytree
@@ -61,6 +61,8 @@ while [ "${*}" != "" ] ; do
             _runtest "There are directories in the fileMeta access directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/directory[@name='access']/directory[@name!='mp3' and @name!='podcast' and @name!='showwaves']/@name" -n "${TEMPTREE}"
             #looks for unexpected files in podcast directory
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.m4a']/@name" -n  "${TEMPTREE}"
+            #looks for any directories within access directory that are not dvd, images, mp3, podcast, or youtube_up
+            _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='mp3' and @name!='showwaves' and @name!='podcast']/@name" -n "${TEMPTREE}"
         else
             # Here are tests for non-audio packages (video and text-based) specifically
             #makes sure there is a service or pdf_1 directory
@@ -73,6 +75,8 @@ while [ "${*}" != "" ] ; do
             _runtest "There are directories in the fileMeta access directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/directory[@name='access']/directory[@name!='dvd' and @name!='mp3' and @name!='podcast' and @name!='youtube_up' and @name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
             #looks for unexpected files in podcast directory
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.mov']/@name" -n  "${TEMPTREE}"
+            #looks for any directories within access directory that are not dvd, images, mp3, podcast, or youtube_up
+            _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='dvd' and @name!='images' and @name!='mp3' and @name!='podcast' and @name!='youtube_up' and @name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
         fi
         #searching for upper-level directories
 
@@ -112,8 +116,6 @@ while [ "${*}" != "" ] ; do
         _runtest "There are directories other than access and service in the objects directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name!='access' and @name!='reformatted' and @name!='service' and @name!='trimmed_materials' and @name!='captions']/@name" -n "${TEMPTREE}"
         #makes sure there is an object in the objects directory
         _runtest -i "There isn't an object in the objects directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/file[count(@name)>0]/@name" -n "${TEMPTREE}"
-        #looks for any directories within access directory that are not dvd, images, mp3, podcast, or youtube_up
-        _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='dvd' and @name!='images' and @name!='mp3' and @name!='podcast' and @name!='youtube_up' and @name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
         #looks for unexpected files in youtube_up directory
         _runtest "There are unexpected files in the youtube_up directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='youtube_up']/file[@name!='${MEDIAID}.mp4' and not(starts-with(@name,'${MEDIAID}_SEG') and substring(@name,string-length(@name)-3)='.mp4')]/@name" -n  "${TEMPTREE}"
         #looks for unexpected directories in youtube_up directory

--- a/verifytree
+++ b/verifytree
@@ -73,6 +73,8 @@ while [ "${*}" != "" ] ; do
             _runtest -i "This package is missing the pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
+            #looks in fileMeta access for unexpected directories that are not pdf_1 or txt_1
+            _runtest "There are directories in the fileMeta access directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='fileMeta']/directory[@name='objects']/directory[@name='access']/directory[@name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
             #looks for any directories within access directory that are not pdf_1 or txt_1
             _runtest "There are unexpected directories in the access directory." xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name!='pdf_1' and @name!='txt_1']/@name" -n "${TEMPTREE}"
         else

--- a/verifytree
+++ b/verifytree
@@ -60,7 +60,11 @@ while [ "${*}" != "" ] ; do
             #looks for unexpected files in podcast directory
             _runtest "There are unexpected files in the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/file[@name!='${MEDIAID}_podcast.m4a']/@name" -n  "${TEMPTREE}"
         else
-            # Here are tests for video packages specifically
+            # Here are tests for non-audio packages (video and text-based) specifically
+            #makes sure there is a service or pdf_1 directory
+            _runtest -i "This package is missing the service or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='service']/@name" -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
+            #makes sure there is a youtube or pdf_1 directory
+            _runtest -i "This package is missing the youtube or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='youtube_up' or @name='pdf_1']/@name" -n "${TEMPTREE}"
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
             #looks for unexpected files in podcast directory
@@ -72,10 +76,6 @@ while [ "${*}" != "" ] ; do
         _runtest "There are directories that are not objects, metadata, or tmp in this package." xmlstarlet sel -t -v "/tree/directory/directory[@name!='objects' and @name!='metadata' and @name!='tmp']/@name" -n "${TEMPTREE}"
         #makes sure there is an objects directory
         _runtest -i "This package is missing an objects directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/@name" -n "${TEMPTREE}"
-        #makes sure there is a service or pdf_1 directory
-        _runtest -i "This package is missing the service or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='service']/@name" -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
-        #makes sure there is a youtube or pdf_1 directory
-        _runtest -i "This package is missing the youtube or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='youtube_up' or @name='pdf_1']/@name" -n "${TEMPTREE}"
         #makes sure there is a metadata directory
         _runtest -i "This package is missing a metadata directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/@name" -n "${TEMPTREE}"
 

--- a/verifytree
+++ b/verifytree
@@ -69,13 +69,15 @@ while [ "${*}" != "" ] ; do
               # Here are tests for text packages specifically
             #makes sure there is a pdf_1 directory
             _runtest -i "This package is missing the pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
+            #makes sure there is a pdf_1 directory
+            _runtest -i "This package is missing the pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='pdf_1']/@name" -n "${TEMPTREE}"
         else
              _report -dt "running verifytree in video mode on ${PACKAGE}" #the name of the package being verified
             # Here are tests for non-audio packages (video and text-based) specifically
-            #makes sure there is a youtube or pdf_1 directory
-            _runtest -i "This package is missing the youtube or pdf_1 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='youtube_up' or @name='pdf_1']/@name" -n "${TEMPTREE}"
             #makes sure there is a service directory
             _runtest -i "This package is missing the service directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='service']/@name" -n "${TEMPTREE}"
+            #makes sure there is a youtube directory
+            _runtest -i "This package is missing the youtube directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='youtube_up']/@name" -n "${TEMPTREE}"
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
             #looks in fileMeta access for unexpected directories that are not dvd, mp3, podcast, or youtube_up

--- a/verifytree
+++ b/verifytree
@@ -58,6 +58,8 @@ while [ "${*}" != "" ] ; do
              # Here are tests for audio packages specifically
              #makes sure there is a podcast directory
              _runtest -i "This package is missing the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/@name" -n "${TEMPTREE}"
+             #makes sure there is a mp3 directory
+             _runtest -i "This package is missing the mp3 directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='mp3']/@name" -n "${TEMPTREE}"
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-3)!='xlsx' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-2)!='log']/@name" -n "${TEMPTREE}"
             #looks in fileMeta access for unexpected directories that are not dvd, mp3, podcast, or youtube_up

--- a/verifytree
+++ b/verifytree
@@ -56,6 +56,8 @@ while [ "${*}" != "" ] ; do
         if [[ "${OBJECTCOUNT}" = 1 && "${FIRSTOBJECTEXTENSION}" = "wav" ]] ; then
             _report -dt "running verifytree in audio mode on ${PACKAGE}" #the name of the package being verified
              # Here are tests for audio packages specifically
+             #makes sure there is a podcast directory
+             _runtest -i "This package is missing the podcast directory!" xmlstarlet sel -t -v "/tree/directory/directory[@name='objects']/directory[@name='access']/directory[@name='podcast']/@name" -n "${TEMPTREE}"
             #looks in logs directory for any files that aren't .log or .txt
             _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-3)!='xlsx' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-2)!='log']/@name" -n "${TEMPTREE}"
             #looks in fileMeta access for unexpected directories that are not dvd, mp3, podcast, or youtube_up

--- a/verifytree
+++ b/verifytree
@@ -52,6 +52,16 @@ while [ "${*}" != "" ] ; do
         OBJECTCOUNT="$(xmlstarlet sel -t -m "/tree/directory/directory[@name='objects']" -v "count(file)" -n "${TEMPTREE}")"
         #check extension of first object file
         FIRSTOBJECTEXTENSION="$(xmlstarlet sel -t -m "/tree/directory/directory[@name='objects']/file[1]" -v "substring-after(@name, '.')" -n  "${TEMPTREE}")"
+        #if there is one object file and it uses a .wav extension, then run audio-specific tests 
+        if [[ "${OBJECTCOUNT}" = 1 && "${FIRSTOBJECTEXTENSION}" = "wav" ]] ; then
+             # Here are tests for audio packages specifically
+            #looks in logs directory for any files that aren't .log or .txt
+            _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-3)!='xlsx' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-2)!='log']/@name" -n "${TEMPTREE}"
+        else
+            # Here are tests for video packages specifically
+            #looks in logs directory for any files that aren't .log or .txt
+            _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
+        fi
         #searching for upper-level directories
 
         #looks for any directories that are not objects or metadata or tmp (for digitized materials)
@@ -73,8 +83,6 @@ while [ "${*}" != "" ] ; do
         _runtest -i "This package needs a checksum.md5!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/file[@name='checksum.md5']/@name" -n "${TEMPTREE}"
         #begins search of metadata subdirectories, looks for directories that do not belong
         _runtest "There are directories in the metadata directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name!='depictions' and @name!='fileMeta' and @name!='frameMD5s' and @name!='logs' and @name!='fingerprints']/@name" -n "${TEMPTREE}"
-        #looks in logs directory for any files that aren't .log or .txt
-        _runtest "There are files in the logs directory that do not belong!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[substring(@name,string-length(@name)-2)!='log' and substring(@name,string-length(@name)-2)!='txt' and substring(@name,string-length(@name)-3)!='jpeg' and substring(@name,string-length(@name)-2)!='.gz' and substring(@name,string-length(@name)-2)!='md5']/@name" -n "${TEMPTREE}"
         #makes sure there is a capture.log in the log directory
         _runtest -i "This package needs a capture.log!" xmlstarlet sel -t -v "/tree/directory/directory[@name='metadata']/directory[@name='logs']/file[@name='capture.log']/@name" -n "${TEMPTREE}"
         #makes sure there is a fileMeta directory


### PR DESCRIPTION
Split up verifytree tests into sections for audio, text, and non-audio (video and text) packages, added podcast and mp3 file sections in verifypackage, and expanded object_policies.xml to include audio files.