### PR TITLE
the official ffmpeg formula has no longer options …

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ mediamicroservice dependencies:
 * dvdauthor
 * exiftool
 * sdl
-* ffmpeg --with-sdl2 --with-freetype
+* ffmpeg
 * flac
 * ltopers (optional)
 * hashdeep


### PR DESCRIPTION
… but `sdl2` and `freetype` are enabled by default.